### PR TITLE
Add a test stage to the Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,5 +11,20 @@ pipeline {
                 sh 'python -m py_compile sources/add2vals.py sources/calc.py' 
             }
         }
+        stage('Test') {
+            agent {
+                docker {
+                    image 'qnib/pytest'
+                }
+            }
+            steps {
+                sh 'py.test --verbose --junit-xml text-reports/results.xml sources/test_calc.py'
+            }
+            post {
+                always {
+                    junit 'test-reports/results.xml'
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Added a `stage` directive called `Test` that appears on the Jenkins UI.

Added the `image` parameter that downloads the `qnib:pytest` Docker image (if not available locally) and runs it as a separate container. The `pytest` container becomes the agent that Jenkins uses to run the `Test` stage of your Pipeline project.

The `pytest` container's lifespan lasts the duration of your `Test` stage's execution.