### PR TITLE
Add a deliver stage to the Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
     agent none 
+    options {
+        skipStagesAfterUnstable()
+    }
     stages {
         stage('Build') { 
             agent {
@@ -23,6 +26,21 @@ pipeline {
             post {
                 always {
                     junit 'test-reports/results.xml'
+                }
+            }
+        }
+        stage('Deliver') {
+            agent {
+                docker {
+                    image 'cdrx/pyinstaller-linux:python2'
+                }
+            }
+            steps {
+                sh 'pyinstaller --onefile sources/add2vals.py'
+            }
+            post {
+                success {
+                    archiveArtifacts 'dist/add2vals'
                 }
             }
         }


### PR DESCRIPTION
Added a `stage` called `Deliver` that appears on the Jenkins UI.

`image` downloads the cdrx/pyinstaller-linux Docker image if it is not locally available and runs this image as a separate container.

The PyInstaller container becomes the `agent` that Jenkins uses to run the `Deliver` stage of the Pipeline and its lifespan lasts the duration of `Deliver` stage's execution.

The `sh` step (of the `steps` section) executes the `pyinstaller` command (in the PyInstaller container) on the Python application.

This bundles your `add2vals.py` Python application into a single standalone executable file (via the `--one-file` option) and outputs the this file to the `dist` workspace directory
(within the Jenkins home directory).

`archiveArtifacts` step (from Jenkins core) archives the standalone executable file (generated by the `pyinstaller` command) and exposes this file through the Jenkins interface.

Archived Artifacts are accessible in Blue Ocean through the Artifacts page of a pipeline run. The `post` section's `success` condition that contains the `archiveArtifacts` step ensures that the step
is executed at the completion of the `Deliver` stage only if this stage completed successfully.

As a general principle, keep Pipeline code (i.e. the `Jenkinsfile`) as tidy as possible and place more complex build steps (particularly for stages consisting of 2 or more steps) into separate shell script files like the `deliver.sh` file.

This makes maintenance of Pipeline code easier, especially if your Pipeline gains more complexity.